### PR TITLE
indent switch cases

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,7 @@
   },
   "rules": {
     "semi": 2,
-    "indent": [2, 2],
+    "indent": [2, 2, { "SwitchCase": 1}],
     "camelcase": 2,
     "no-unused-vars": 1,
     "prefer-const": 2,


### PR DESCRIPTION
VS and VS Code both default to indenting `case`s within a `switch()` block.

This change has eslint enforce that, rather than enforcing `case`s at the same level as the containing `switch()` which it was doing by default.